### PR TITLE
Adding soft deletion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.jar
 !citadel.jar
 *~
+/target/

--- a/.project
+++ b/.project
@@ -10,8 +10,14 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
 </projectDescription>

--- a/.settings/org.eclipse.jdt.core.prefs
+++ b/.settings/org.eclipse.jdt.core.prefs
@@ -8,4 +8,5 @@ org.eclipse.jdt.core.compiler.debug.localVariable=generate
 org.eclipse.jdt.core.compiler.debug.sourceFile=generate
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
 org.eclipse.jdt.core.compiler.source=1.7

--- a/config.yml
+++ b/config.yml
@@ -14,5 +14,6 @@ settings:
   allowTriggeringLevers: false
   togglerestartgroupcheck: false
   displayOwnerOnSnitchBreak: true
+  softDelete: true
 mercury:
   broadcastallservers: false

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,6 +1,6 @@
-name: JukeAlert
+name: ${project.name}
 main: com.untamedears.JukeAlert.JukeAlert
-version: 1.3.5
+version: ${project.version}
 depend: [Citadel, NameLayer]
 softdepend: [vanishnopacket, ItemExchange, Mercury]
 description: JukeAlert provides an easy-to-use means by which one can record player activity within an 11 block radius. Anything someone does while within eleven blocks of a jukebox you've reinforced will be logged on it, and can be read by looking at the jukebox and typing '/jainfo'.

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>com.untamedears</groupId>
   <artifactId>JukeAlert</artifactId>
   <packaging>jar</packaging>
-  <version>1.3.63</version>
+  <version>1.3.7</version>
   <name>JukeAlert</name>
   <url>https://github.com/Civcraft/JukeAlert/</url>
 
@@ -28,6 +28,7 @@
           <include>*.yml</include>
           <include>LICENSE.txt</include>
         </includes>
+        <filtering>true</filtering>
       </resource>
     </resources>
   </build>
@@ -35,8 +36,8 @@
   <dependencies>
     <dependency>
       <groupId>org.spigotmc</groupId>
-      <artifactId>Spigot1.8.3</artifactId>
-      <version>1.8.3</version>
+      <artifactId>spigot-api</artifactId>
+      <version>1.8.3-R0.1-SNAPSHOT</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -75,6 +76,14 @@
     <repository>
       <id>civcraft-repo</id>
       <url>http://build.civcraft.co:8080/plugin/repository/everything/</url>
+    </repository>
+    <repository>
+      <id>spigot-repo</id>
+      <url>https://hub.spigotmc.org/nexus/content/groups/public/</url>
+    </repository>
+    <repository>
+      <id>kitteh-repo</id>
+      <url>http://repo.kitteh.org/content/groups/public</url>
     </repository>
   </repositories>
 </project>

--- a/src/com/untamedears/JukeAlert/manager/ConfigManager.java
+++ b/src/com/untamedears/JukeAlert/manager/ConfigManager.java
@@ -42,6 +42,7 @@ public class ConfigManager
     private boolean enableInvisibility;
     private boolean toggleRestartCheckGroup;
     private boolean displayOwnerOnBreak;
+    private boolean softDelete;
     
     private boolean broadcastAllServers;
 
@@ -114,6 +115,7 @@ public class ConfigManager
         enableInvisibility = loadBoolean("settings.enableinvisiblity", false);
         toggleRestartCheckGroup = loadBoolean("settings.togglerestartgroupcheck", false);
         displayOwnerOnBreak = loadBoolean("settings.displayOwnerOnSnitchBreak", true);
+        softDelete = loadBoolean("settings.softDelete", true);
 
         broadcastAllServers = loadBoolean("mercury.broadcastallservers", false);
         
@@ -365,6 +367,10 @@ public class ConfigManager
 
     public boolean isDisplayOwnerOnBreak() {
         return displayOwnerOnBreak;
+    }
+    
+    public boolean isSoftDelete() {
+    	return softDelete;
     }
     
     public boolean getToggleRestartCheckGroup(){


### PR DESCRIPTION
Basically doesn't delete from the database. Only the Culling tasks will. This gives persistent records to snitch logs without need for loading backups, etc. while still alloying them to gracefully expire in time. 

Why is this helpful? 

How many times have you been investigating x-ray allegations but the accused destroyed all the snitches? And, because they destroyed them in-game, the records are gone from the database as well. Unless you have some other magical player tracker, you're screwed in terms of investigation -- at best you can guess or infer, or monitor the accused in the future, but that's it. 

This provides a solution. The records will still exist, so you can check with confidence for any variety of "cheaty" actions that would appear on snitch logs (digging straight to things, etc.).

Lemme know if I missed anything.
