### PR TITLE
Fix an off-by-one bug with /janame

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>com.untamedears</groupId>
 	<artifactId>JukeAlert</artifactId>
 	<packaging>jar</packaging>
-	<version>1.4.4</version>
+	<version>1.4.7</version>
 	<name>JukeAlert</name>
 	<url>https://github.com/DevotedMC/JukeAlert/</url>
 

--- a/src/main/java/com/untamedears/JukeAlert/command/commands/NameCommand.java
+++ b/src/main/java/com/untamedears/JukeAlert/command/commands/NameCommand.java
@@ -32,7 +32,7 @@ public class NameCommand extends PlayerCommand {
 
             String name = "";
             if (args[0].length() > 40) {
-                name = args[0].substring(0, 39);
+                name = args[0].substring(0, 40);
             } else {
             	name = args[0];
             }


### PR DESCRIPTION
Steps to reproduce:
1. Name a snitch with a 40-length string.
2. The length displayed in /jalist is 40 (hover over the snitch entry)
3. Name a snitch with a 41-length string.
3. The length displayed in /jalist is 39.

/jainfo would work too obviously, as long as https://github.com/DevotedMC/JukeAlert/pull/9 is merged.