### PR TITLE
Fix ghost entry snitches

### DIFF
--- a/src/main/java/com/untamedears/JukeAlert/listener/JukeAlertListener.java
+++ b/src/main/java/com/untamedears/JukeAlert/listener/JukeAlertListener.java
@@ -392,9 +392,6 @@ public class JukeAlertListener implements Listener {
 					+ " and is on group: " + snitch.getGroup().getName());
 			}
 		}
-		if (!block.getType().equals(Material.JUKEBOX)) {
-			return;
-		}
 		if (vanishNoPacket.isPlayerInvisible(event.getPlayer())
 				|| event.getPlayer().hasPermission("jukealert.vanish")) {
 			return;
@@ -402,10 +399,8 @@ public class JukeAlertListener implements Listener {
 		Location loc = block.getLocation();
 		if (snitchManager.getSnitch(loc.getWorld(), loc) != null) {
 			Snitch snitch = snitchManager.getSnitch(loc.getWorld(), loc);
-			if (snitch.shouldLog()) {
-				plugin.getJaLogger().logSnitchBreak(loc.getWorld().getName(), loc.getBlockX(), loc.getBlockY(),
-					loc.getBlockZ());
-			}
+			plugin.getJaLogger().logSnitchBreak(loc.getWorld().getName(), loc.getBlockX(), loc.getBlockY(),
+				loc.getBlockZ());
 			snitchManager.removeSnitch(snitch);
 		}
 	}


### PR DESCRIPTION
To reproduce:
 1. Place down an entry snitch
 2. Break it
 3. Place down a logging snitch at the same coordinates
 4. Run /jainfo

**Expected result:** The snitch shows up as a logging one.
**What actually happens:** The snitch shows up and behaves like an entry one.