### PR TITLE
Fix /jamute muting too many groups

### DIFF
--- a/src/main/java/com/untamedears/JukeAlert/storage/JukeAlertLogger.java
+++ b/src/main/java/com/untamedears/JukeAlert/storage/JukeAlertLogger.java
@@ -1633,7 +1633,7 @@ public class JukeAlertLogger {
 		} else {
 			// Add the first value
 			String[] mutedGroups = set.getString(2).split("\\s+");
-			List<String> mutedGroupsSet = new ArrayList<String>(Arrays.asList(mutedGroups));
+			List<String> mutedGroupsSet = Arrays.asList(mutedGroups);
 			if (mutedGroupsSet.contains(ignoredGroup)) {
 				ignoringUsers.add(set.getString(1));
 			}
@@ -1641,7 +1641,7 @@ public class JukeAlertLogger {
 			while (set.next()) {
 				// Create set of uuids
 				mutedGroups = set.getString(2).split("\\s+");
-				mutedGroupsSet = new ArrayList<String>(Arrays.asList(mutedGroups));
+				mutedGroupsSet = Arrays.asList(mutedGroups);
 				if (mutedGroupsSet.contains(ignoredGroup)) {
 					ignoringUsers.add(set.getString(1));
 				}

--- a/src/main/java/com/untamedears/JukeAlert/storage/JukeAlertLogger.java
+++ b/src/main/java/com/untamedears/JukeAlert/storage/JukeAlertLogger.java
@@ -1632,11 +1632,19 @@ public class JukeAlertLogger {
 			return null;
 		} else {
 			// Add the first value
-			ignoringUsers.add(set.getString(1));
+			String[] mutedGroups = set.getString(2).split("\\s+");
+			Set<String> mutedGroupsSet = new HashSet<String>(Arrays.asList(mutedGroups));
+			if (mutedGroupsSet.contains(ignoredGroup)) {
+				ignoringUsers.add(set.getString(1));
+			}
 			// Now if there is more loop through them
 			while (set.next()) {
 				// Create set of uuids
-				ignoringUsers.add(set.getString(1));
+				mutedGroups = set.getString(2).split("\\s+");
+				mutedGroupsSet = new HashSet<String>(Arrays.asList(mutedGroups));
+				if (mutedGroupsSet.contains(ignoredGroup)) {
+					ignoringUsers.add(set.getString(1));
+				}
 			}
 		}
 		return ignoringUsers;

--- a/src/main/java/com/untamedears/JukeAlert/storage/JukeAlertLogger.java
+++ b/src/main/java/com/untamedears/JukeAlert/storage/JukeAlertLogger.java
@@ -1633,7 +1633,7 @@ public class JukeAlertLogger {
 		} else {
 			// Add the first value
 			String[] mutedGroups = set.getString(2).split("\\s+");
-			Set<String> mutedGroupsSet = new HashSet<String>(Arrays.asList(mutedGroups));
+			List<String> mutedGroupsSet = new ArrayList<String>(Arrays.asList(mutedGroups));
 			if (mutedGroupsSet.contains(ignoredGroup)) {
 				ignoringUsers.add(set.getString(1));
 			}
@@ -1641,7 +1641,7 @@ public class JukeAlertLogger {
 			while (set.next()) {
 				// Create set of uuids
 				mutedGroups = set.getString(2).split("\\s+");
-				mutedGroupsSet = new HashSet<String>(Arrays.asList(mutedGroups));
+				mutedGroupsSet = new ArrayList<String>(Arrays.asList(mutedGroups));
 				if (mutedGroupsSet.contains(ignoredGroup)) {
 					ignoringUsers.add(set.getString(1));
 				}


### PR DESCRIPTION
Fixes https://github.com/DevotedMC/JukeAlert/issues/31

A workaround, might hurt performance, might not. A proper solution would involve changing the way the /jamute group data is stored in the DB.