### PR TITLE
Fix incorrect bracketing causing NPE

### DIFF
--- a/src/main/java/com/untamedears/JukeAlert/util/OnlineGroupMembers.java
+++ b/src/main/java/com/untamedears/JukeAlert/util/OnlineGroupMembers.java
@@ -193,8 +193,8 @@ public class OnlineGroupMembers implements Iterable<Player>, Iterator<Player> {
 				if (g.getPlayerType(uuid) == PlayerType.MEMBERS && !g.getOwner().equals(uuid)) {
 					members.add(Bukkit.getOfflinePlayer(uuid));
 				}
-			member_iter_ = members.iterator();
 			}
+			member_iter_ = members.iterator();
 		}
 		while (member_iter_.hasNext()) {
 			OfflinePlayer member = member_iter_.next();


### PR DESCRIPTION
Resolves DevotedMC/JukeAlert#4.

This would happen when the group in question is empty, meaning the for-loop never went through, meaning `member_iter_` was never set. This was probably just a typo, since the indentation indicates that it should have been outside the loop all along.