### PR TITLE
Fix nickname cutoff in /jainfo (#56)

### DIFF
--- a/src/main/java/com/untamedears/JukeAlert/storage/JukeAlertLogger.java
+++ b/src/main/java/com/untamedears/JukeAlert/storage/JukeAlertLogger.java
@@ -1471,7 +1471,8 @@ public class JukeAlertLogger {
 		final Snitch snitch = JukeAlert.getInstance().getSnitchManager().getSnitch(snitchID);
 		final String name = (snitch == null) ? "" : snitch.getName();
 
-		final String initiator = ChatFiller.fillString(entry.getInitiateUser(), 22.0);
+		// Must be at least 24.0 not to cut off long and/or wide nicknames (https://github.com/DevotedMC/JukeAlert/issues/56)
+		final String initiator = ChatFiller.fillString(entry.getInitiateUser(), 24.0);
 		final String victim = entry.getVictim();
 		final int actionValue = entry.getSnitchActionId();
 		final LoggedAction action = entry.getAction();


### PR DESCRIPTION
Fixes https://github.com/DevotedMC/JukeAlert/issues/56

Tested with 16 of the longest-width character I could think of – W. The first screenshot in the issue is the fixed version.