### PR TITLE
Fix entry snitches in the /ja GUI

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>com.untamedears</groupId>
 	<artifactId>JukeAlert</artifactId>
 	<packaging>jar</packaging>
-	<version>1.6.1</version>
+	<version>1.6.2</version>
 	<name>JukeAlert</name>
 	<url>https://github.com/DevotedMC/JukeAlert/</url>
 
@@ -56,7 +56,7 @@
 		<dependency>
 			<groupId>org.kitteh</groupId>
 			<artifactId>VanishNoPacket</artifactId>
-			<version>3.20</version>
+			<version>3.19</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/src/main/java/com/untamedears/JukeAlert/gui/SnitchLogGUI.java
+++ b/src/main/java/com/untamedears/JukeAlert/gui/SnitchLogGUI.java
@@ -46,20 +46,23 @@ public class SnitchLogGUI {
 
 		MultiPageView view = new MultiPageView(player, constructContent(), snitch.getName().substring(0,
 			Math.min(32, snitch.getName().length())), true);
-		view.setMenuSlot(constructClearClick(), 1);
 		if (snitch.shouldLog()) {
+			view.setMenuSlot(constructClearClick(), 1);
 			view.setMenuSlot(constructLeverToggleClick(), 5);
+		} else {
+			// this makes sure the view stays centred
+			view.setMenuSlot(new DecorationStack(null), 1);
 		}
-		view.setMenuSlot(constructNameChanceClick(), 2);
-		view.setMenuSlot(constructExitClick(), 4);
+ 		view.setMenuSlot(constructNameChanceClick(), 2);
 		view.setMenuSlot(constructInfoStack(), 3);
+		view.setMenuSlot(constructExitClick(), 4);
 		view.showScreen();
 	}
 
 	private IClickable constructInfoStack() {
 
 		ItemStack is = new ItemStack(Material.PAPER);
-		ISUtils.setName(is, ChatColor.GOLD + "Logs for " + snitch.getName());
+		ISUtils.setName(is, ChatColor.GOLD + (snitch.shouldLog() ? "Logs for " : "Entry snitch ") + snitch.getName());
 		ISUtils.addLore(
 			is, ChatColor.AQUA + "Located at " + snitch.getX() + ", " + snitch.getY() + ", " + snitch.getZ());
 		ISUtils.addLore(is, ChatColor.YELLOW + "Group: " + snitch.getGroup().getName());

--- a/src/main/java/com/untamedears/JukeAlert/gui/SnitchOverviewGUI.java
+++ b/src/main/java/com/untamedears/JukeAlert/gui/SnitchOverviewGUI.java
@@ -37,7 +37,7 @@ public class SnitchOverviewGUI {
 
 		List<IClickable> clicks = new LinkedList<IClickable>();
 		for (final Snitch snitch : snitches) {
-			ItemStack is = new ItemStack(Material.JUKEBOX);
+			ItemStack is = new ItemStack(snitch.shouldLog() ? Material.JUKEBOX : Material.NOTE_BLOCK);
 			ISUtils.setName(is, ChatColor.GOLD + snitch.getName());
 			ISUtils.addLore(
 				is, ChatColor.AQUA + "Located at " + snitch.getX() + ", " + snitch.getY() + ", " + snitch.getZ());


### PR DESCRIPTION
- Entry snitches now show up as a noteblock in the GUI
- Entry snitches no longer offer the "clear logs" option in the GUI
- The paper info item in the /ja GUI now says "Entry snitch" instead of "Logs for" when applicable.
- Changed VanishNoPacket version to 3.19 because 3.20 was not in any repos and it still compiles fine

I actually tested this btw