### PR TITLE
Fix items (fixes #28, #62)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>com.untamedears</groupId>
 	<artifactId>JukeAlert</artifactId>
 	<packaging>jar</packaging>
-	<version>1.6.2</version>
+	<version>1.6.4</version>
 	<name>JukeAlert</name>
 	<url>https://github.com/DevotedMC/JukeAlert/</url>
 

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
 		<dependency>
 			<groupId>org.spigotmc</groupId>
 			<artifactId>spigot-api</artifactId>
-			<version>1.12-R0.1-SNAPSHOT</version>
+			<version>1.12.2-R0.1-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/src/main/java/com/untamedears/JukeAlert/gui/SnitchLogGUI.java
+++ b/src/main/java/com/untamedears/JukeAlert/gui/SnitchLogGUI.java
@@ -1,5 +1,6 @@
 package com.untamedears.JukeAlert.gui;
 
+import com.untamedears.JukeAlert.util.Utility;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -166,21 +167,21 @@ public class SnitchLogGUI {
 			ItemStack is;
 			switch (action.getAction()) {
 				case BLOCK_BREAK:
-					is = new ItemStack(action.getMaterial());
+					is = Utility.materialToGuiItem(action.getMaterial());
 					ISUtils.setName(is, ChatColor.GOLD + action.getMaterial().toString()
 					                                   + " broken by " + action.getInitiateUser());
 					break;
 				case BLOCK_BURN:
-					is = new ItemStack(action.getMaterial());
+					is = Utility.materialToGuiItem(action.getMaterial());
 					ISUtils.setName(is, ChatColor.GOLD + action.getMaterial().toString() + " was destroyed by fire");
 					break;
 				case BLOCK_PLACE:
-					is = new ItemStack(action.getMaterial());
+					is = Utility.materialToGuiItem(action.getMaterial());
 					ISUtils.setName(is, ChatColor.GOLD + action.getMaterial().toString()
 					                                   + " placed by " + action.getInitiateUser());
 					break;
 				case BLOCK_USED:
-					is = new ItemStack(action.getMaterial());
+					is = Utility.materialToGuiItem(action.getMaterial());
 					ISUtils.setName(is,
 							ChatColor.GOLD + action.getMaterial().toString() + " used by " + action.getInitiateUser());
 					break;

--- a/src/main/java/com/untamedears/JukeAlert/util/Utility.java
+++ b/src/main/java/com/untamedears/JukeAlert/util/Utility.java
@@ -11,6 +11,7 @@ import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
 import org.bukkit.util.BlockIterator;
 
 import net.md_5.bungee.api.chat.TextComponent;
@@ -188,6 +189,69 @@ public class Utility {
 			return "W";
 		} else {
 			return "SW";
+		}
+	}
+
+	public static ItemStack materialToGuiItem(Material material) {
+		if (material.isItem()) {
+			return new ItemStack(material);
+		} else {
+			return new ItemStack(materialToItem(material));
+		}
+	}
+
+	private static Material materialToItem(Material material) {
+		// common materials that can't show up on a gui
+		switch (material) {
+			case CARROT:
+				return Material.CARROT_ITEM;
+			case CROPS:
+				return Material.SEEDS;
+			case POTATO:
+				return Material.POTATO_ITEM;
+			case BEETROOT_BLOCK:
+				return Material.BEETROOT_SEEDS;
+			case SUGAR_CANE_BLOCK:
+				return Material.SUGAR_CANE;
+			case BREWING_STAND:
+				return Material.BREWING_STAND_ITEM;
+			case CAULDRON:
+				return Material.CAULDRON_ITEM;
+			case SKULL:
+				return Material.SKULL_ITEM;
+			case WALL_SIGN:
+			case SIGN_POST:
+				return Material.SIGN;
+			case STANDING_BANNER:
+			case WALL_BANNER:
+				return Material.BANNER;
+			case FLOWER_POT:
+				return Material.FLOWER_POT_ITEM;
+			case REDSTONE_COMPARATOR_OFF:
+			case REDSTONE_COMPARATOR_ON:
+				return Material.REDSTONE_COMPARATOR;
+			case DIODE_BLOCK_OFF:
+			case DIODE_BLOCK_ON:
+				// redstone repeater
+				return Material.DIODE;
+			case DARK_OAK_DOOR:
+				return Material.DARK_OAK_DOOR_ITEM;
+			case ACACIA_DOOR:
+				return Material.ACACIA_DOOR_ITEM;
+			case BIRCH_DOOR:
+				return Material.BIRCH_DOOR_ITEM;
+			case SPRUCE_DOOR:
+				return Material.SPRUCE_DOOR_ITEM;
+			case JUNGLE_DOOR:
+				return Material.JUNGLE_DOOR_ITEM;
+			case IRON_DOOR_BLOCK:
+				return Material.IRON_DOOR;
+			case WOODEN_DOOR:
+				// minecraft why do you have wood door and wooden door??
+				return Material.WOOD_DOOR;
+			default:
+				// fallback to just use a stone block if we can't get any other item on the gui
+				return Material.STONE;
 		}
 	}
 }


### PR DESCRIPTION
JukeAlert will now show everything in the GUI as an item instead of nothing at all. I have included some mappings for most non-item blocks, and the plugin will use stone if it can't find any valid item.